### PR TITLE
fixed product and tag routes

### DIFF
--- a/routes/api/product-routes.js
+++ b/routes/api/product-routes.js
@@ -16,9 +16,7 @@ router.get('/', async (req, res) => {
         },
         {
           model: Tag,
-        },
-        {
-          model: ProductTag,
+          through: ProductTag,
         },
       ],
     });
@@ -41,9 +39,7 @@ router.get('/:id', async (req, res) => {
       },
       {
         model: Tag,
-      },
-      {
-        model: ProductTag,
+        through: ProductTag,
       },
     ], 
   } );

--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -33,9 +33,7 @@ router.get('/:id', async (req, res) => {
       include: [
         {
           model: Product,
-        },
-        {
-          model: ProductTag,
+          through: ProductTag,
         },
       ],
     });


### PR DESCRIPTION
fixed product and tag routes to have the correct  'through' association syntax of:
  ` include: [
        {
          model: Product,
          through: ProductTag,
        },
      ],`